### PR TITLE
Fix bug when adding a text file to multipart request

### DIFF
--- a/request/CRCMultipartRequest.m
+++ b/request/CRCMultipartRequest.m
@@ -61,14 +61,16 @@
                     [body appendData: [@"Content-Type: application/x-gzip\r\n\r\n" dataUsingEncoding: NSUTF8StringEncoding]];
                     [body appendData: [[NSData dataWithContentsOfFile: [path relativePath]] gzipped]];
                 }
-                /* A «smarter» way, perhaps */
-                else if ( ! [[NSWorkspace sharedWorkspace] type: uti conformsToType: (NSString *)kUTTypeText])
+                else
+                {
+                    /* A «smarter» way, perhaps */
+                    if ( ! [[NSWorkspace sharedWorkspace] type: uti conformsToType: (NSString *)kUTTypeText])
                     {
-                        [body appendData: [@"Content-Transfer-Encoding: binary\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
-                        [body appendData: [[NSString stringWithFormat:@"Content-Type: %@\r\n\r\n", mimeType] dataUsingEncoding:NSUTF8StringEncoding]];
-                        [body appendData: [NSData dataWithContentsOfFile: [path relativePath]]];
-                    }		
-				
+                        [body appendData: [@"Content-Transfer-Encoding: binary\r\n" dataUsingEncoding:NSUTF8StringEncoding]];                        
+                    }
+                    [body appendData: [[NSString stringWithFormat:@"Content-Type: %@\r\n\r\n", mimeType] dataUsingEncoding:NSUTF8StringEncoding]];
+                    [body appendData: [NSData dataWithContentsOfFile: [path relativePath]]];
+                }
 			}
 		}
 


### PR DESCRIPTION
We can not add any text file to a request body for now, because in my last pull request #20:  

I've put `[body appendData: #file#];` in the `if ( ! [type: uti conformsToType:])` section, so it only occurs if file has a non-text UTI.
