### PR TITLE
Delete selected request when pressing backspace

### DIFF
--- a/core/CocoaRestClientAppDelegate.m
+++ b/core/CocoaRestClientAppDelegate.m
@@ -1573,6 +1573,12 @@ static CRCContentType requestContentType;
 
 - (IBAction)deleteRow:(id)sender {
     NSLog(@"Calling delete row");
+    
+    if ([window firstResponder] == savedOutlineView) {
+        [self deleteSavedRequest: sender];
+        return;
+    }
+    
     NSString *currentTabLabel = [[tabView selectedTabViewItem] label];
     if ([currentTabLabel isEqualToString:@"Request Headers"] && [headersTableView selectedRow] > -1) {
         [self minusHeaderRow:sender];


### PR DESCRIPTION
Instead of deleting the last selected header/parameter/file when pressing backspace,
delete the selected request if the saved requests outline view is in focus.